### PR TITLE
Enforced Referential Integrity & Added Database Validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,10 @@ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
+
+gem 'immigrant'
+
+
 # Use Sass to process CSS
 # gem "sassc-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,8 @@ GEM
       activesupport (>= 5.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    immigrant (0.3.6)
+      activerecord (>= 3.0)
     importmap-rails (1.1.5)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
@@ -212,6 +214,7 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  immigrant
   importmap-rails
   jbuilder
   puma (~> 5.0)

--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -22,6 +22,8 @@ class BookingsController < ApplicationController
 
   # POST /bookings or /bookings.json
   def create
+
+    @flight = Flight.find(booking_params[:flight_id])
     @booking = Booking.new(booking_params)
 
     respond_to do |format|

--- a/app/models/airline.rb
+++ b/app/models/airline.rb
@@ -1,3 +1,6 @@
 class Airline < ApplicationRecord
   has_many :flights
+
+  validates :code, presence: true, uniqueness: true, length: { is: 2 }, format: { with: /\A[A-Z]+\z/, message: "only allows uppercase letters" }
+  validates :name, presence: true, length: { maximum: 100 }  
 end

--- a/app/models/airport.rb
+++ b/app/models/airport.rb
@@ -1,4 +1,7 @@
 class Airport < ApplicationRecord
   has_many :departs, class_name: "Flight", foreign_key: "depart_id"
   has_many :arrives, class_name: "Flight", foreign_key: "arrive_id"
+
+  validates :code, presence: true, uniqueness: true, length: { is: 3 }, format: { with: /\A[A-Z]+\z/, message: "only allows uppercase letters" }
+  validates :name, presence: true, length: { maximum: 100 }
 end

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -3,4 +3,14 @@ class Booking < ApplicationRecord
   has_many :passengers
 
   accepts_nested_attributes_for :passengers
+
+  validate :passengers_count
+
+  def passengers_count
+    if passengers.size < 1
+      errors.add(:base, "At least one passenger is required.")
+    elsif passengers.size > 4
+      errors.add(:base, "At most four passengers are allowed.")
+    end
+  end
 end

--- a/app/models/flight.rb
+++ b/app/models/flight.rb
@@ -3,4 +3,9 @@ class Flight < ApplicationRecord
   belongs_to :arrive, class_name: "Airport"
   belongs_to :airline
   has_many :bookings
+
+
+  validates :start_date_time, presence: true
+  validates :duration_min, presence: true, numericality: { greater_than: 0 }
+  
 end

--- a/app/models/passenger.rb
+++ b/app/models/passenger.rb
@@ -1,3 +1,7 @@
 class Passenger < ApplicationRecord
   belongs_to :booking
+
+  validates :full_name, presence: true, length: { maximum: 100 }
+  validates :email, presence: true, uniqueness: true, length: { maximum: 100 }, format: { with: URI::MailTo::EMAIL_REGEXP }
 end
+

--- a/app/models/passenger.rb
+++ b/app/models/passenger.rb
@@ -1,7 +1,7 @@
 class Passenger < ApplicationRecord
   belongs_to :booking
 
-  validates :full_name, presence: true, length: { maximum: 100 }
+  validates :name, presence: true, length: { maximum: 100 }
   validates :email, presence: true, uniqueness: true, length: { maximum: 100 }, format: { with: URI::MailTo::EMAIL_REGEXP }
 end
 

--- a/app/views/bookings/new.html.erb
+++ b/app/views/bookings/new.html.erb
@@ -1,3 +1,6 @@
+
+
+
 <div class="d-flex flex-column justify-content-center align-items-center">
   <div class="display-6 mb-3 m-4 text-secondary" style="text-align: left; text-decoration: underline"><em>Enter Passenger Information</em></div>
   <div class="display-6 mb-3" style="text-align: left">Flight</div>

--- a/db/migrate/20230421030350_add_foreign_keys.rb
+++ b/db/migrate/20230421030350_add_foreign_keys.rb
@@ -1,0 +1,9 @@
+class AddForeignKeys < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key "bookings", "flights", name: "bookings_flight_id_fk"
+    add_foreign_key "flights", "airlines", name: "flights_airline_id_fk"
+    add_foreign_key "flights", "airports", column: "arrive_id", name: "flights_arrive_id_fk"
+    add_foreign_key "flights", "airports", column: "depart_id", name: "flights_depart_id_fk"
+    add_foreign_key "passengers", "bookings", name: "passengers_booking_id_fk"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_20_061546) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_21_030350) do
   create_table "airlines", force: :cascade do |t|
     t.string "code"
     t.string "name"
@@ -49,4 +49,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_20_061546) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "bookings", "flights", name: "bookings_flight_id_fk"
+  add_foreign_key "flights", "airlines", name: "flights_airline_id_fk"
+  add_foreign_key "flights", "airports", column: "arrive_id", name: "flights_arrive_id_fk"
+  add_foreign_key "flights", "airports", column: "depart_id", name: "flights_depart_id_fk"
+  add_foreign_key "passengers", "bookings", name: "passengers_booking_id_fk"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,11 +5,11 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+Passenger.delete_all
+Booking.delete_all
+Flight.delete_all
 Airport.delete_all
 Airline.delete_all
-Flight.delete_all
-Booking.delete_all
-Passenger.delete_all
 
 airports = [
   { code: "ORD", name: "Chicago O'Hare International Airport" },


### PR DESCRIPTION
Enforce Referential Integrity through Immigrant Gem by creating foreign keys

Defined Rails level Database validation for the models
- Passenger count check when creating bookings (should be 1 - 4)
- presence check for all fields, length < 100 for text fields,  > 0 for numerical fields
- email format check for Passenger